### PR TITLE
fix(gh-actions): adjust trigger for action

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,6 +9,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**.md' # ignore changes in markdown files
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: mei-docker-image
 
 # Controls when the workflow will run

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
This PR adjusts the trigger for the build and push action. It removes the manual workflow dispatch trigger, and sets a path filter to avoid building on Pull Request when changes are made only to Markdown files like the README.