### PR TITLE
fix(gh-actions): do not run action on forks

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-22.04
+    if: ${{ github.repository_owner == 'music-encoding' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR prevents the build action to be run on forks where it throws an error.