### PR TITLE
fix(docker): update dependencies in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 ARG SAXON_VERSION=Saxon-HE/11/Java/SaxonHE11-4J
 ARG XERCES_VERSION=25.1.0.1
+ARG JAVA_VERSION=17
 ARG PRINCE_VERSION=15.1
 ARG UBUNTU_VERSION=22.04
 ARG DEB_FILE=prince_${PRINCE_VERSION}-1_ubuntu${UBUNTU_VERSION}_${TARGETARCH}.deb
@@ -24,7 +25,7 @@ ENV NODE_ENV=production
 USER root
 
 # install packages
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils openjdk-8-jre-headless curl unzip git libc6 aptitude libaom-dev gdebi fonts-stix && \
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils openjdk-${JAVA_VERSION}-jre-headless curl unzip git libc6 aptitude libaom-dev gdebi fonts-stix && \
     # install prince
     curl --proto '=https' --tlsv1.2 -O https://www.princexml.com/download/${DEB_FILE} && \
     gdebi --non-interactive ./${DEB_FILE} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN unzip /tmp/saxon.zip -d ${ANT_HOME}/lib
 ADD https://www.oxygenxml.com/maven/com/oxygenxml/oxygen-patched-xerces/${XERCES_VERSION}/oxygen-patched-xerces-${XERCES_VERSION}.jar ${ANT_HOME}/lib
 
 # cleanup
-RUN apt-get purge -y aptitude apt-utils gdebi curl unzip && \
+RUN apt-get purge -y aptitude apt-utils gdebi curl unzip wget apt-transport-https && \
     apt-get autoremove -y && apt-get clean && \
     rm ${DEB_FILE} nodesource_setup.sh && \
     rm -r /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ LABEL org.opencontainers.image.source="https://github.com/music-encoding/docker-
 LABEL org.opencontainers.image.revision="v0.0.1"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG TARGETARCH
-ARG SAXON_VERSION=Saxon-HE/11/Java/SaxonHE11-4J
-ARG XERCES_VERSION=25.1.0.1
 ARG JAVA_VERSION=17
 ARG PRINCE_VERSION=15.1
+ARG SAXON_VERSION=Saxon-HE/11/Java/SaxonHE11-4J
+ARG TARGETARCH
 ARG UBUNTU_VERSION=22.04
+ARG XERCES_VERSION=25.1.0.1
 ARG DEB_FILE=prince_${PRINCE_VERSION}-1_ubuntu${UBUNTU_VERSION}_${TARGETARCH}.deb
 
 ENV TZ=Europe/Berlin

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.revision="v0.0.1"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG JAVA_VERSION=17
 ARG PRINCE_VERSION=15.1
-ARG SAXON_VERSION=Saxon-HE/11/Java/SaxonHE11-4J
+ARG SAXON_VERSION=SaxonHE11-5
 ARG TARGETARCH
 ARG UBUNTU_VERSION=22.04
 ARG XERCES_VERSION=25.1.0.1
@@ -41,7 +41,7 @@ ADD https://downloads.apache.org/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.
 RUN tar -xvf /tmp/ant.tar.gz -C /opt
 
 # setup saxon
-ADD https://sourceforge.net/projects/saxon/files/${SAXON_VERSION}.zip/download /tmp/saxon.zip
+ADD https://github.com/Saxonica/Saxon-HE/releases/download/${SAXON_VERSION}/${SAXON_VERSION}J.zip /tmp/saxon.zip
 RUN unzip /tmp/saxon.zip -d ${ANT_HOME}/lib
 
 # setup xerces

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,14 @@ ENV NODE_ENV=production
 
 USER root
 
+# Configure the Eclipse Adoptium apt repository
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https && \
+    mkdir -p /etc/apt/keyrings && \
+    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 # install packages
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils openjdk-${JAVA_VERSION}-jre-headless curl unzip git libc6 aptitude libaom-dev gdebi fonts-stix && \
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils temurin-${JAVA_VERSION}-jdk curl unzip git libc6 aptitude libaom-dev gdebi fonts-stix && \
     # install prince
     curl --proto '=https' --tlsv1.2 -O https://www.princexml.com/download/${DEB_FILE} && \
     gdebi --non-interactive ./${DEB_FILE} && \


### PR DESCRIPTION
This PR updates the java version used in the docker image to temurin 17. It also updates the Saxon version and Saxon download path according to https://github.com/music-encoding/music-encoding/pull/1206

It also sorts the arguments a bit more alphabetically.

Fixes #3