### PR TITLE
build: fix svg file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ verovio.module.onRuntimeInitialized = () => {
 
   let stream = walker(['music-encoding/build/assets/images/GeneratedImages'])
 
-  let processFile = (path) => {
-    fs.readFile(path, 'utf-8', (err, data) => {
+  let processFile = (filePath) => {
+    fs.readFile(filePath, 'utf-8', (err, data) => {
       if (err) {
         console.error(err)
         return
@@ -35,17 +35,19 @@ verovio.module.onRuntimeInitialized = () => {
 
       try {
         let svg = tk.renderData(data, verovioOptions);
-        fs.writeFile(path + '.svg', svg, writingError => {
+        let dotIndex = filePath.lastIndexOf('.');
+        let svgFilePath = filePath.substring(0, dotIndex) + '.svg';
+        fs.writeFile(svgFilePath, svg, writingError => {
           if (err) {
             console.error(writingError)
             return
           }
           //file written successfully
         })
-        console.log('\x1b[32m%s\x1b[0m', 'Successfully rendered ' + path)
+        console.log('\x1b[32m%s\x1b[0m', 'Successfully rendered ' + svgFilePath)
        
       } catch(renderError) {
-        console.log('Unable to render ' + path + ':')
+        console.log('Unable to render ' + filePath + ':')
         //console.error(renderError)
       }
       //console.log(data)


### PR DESCRIPTION
This PR fixes the file path creation for the svg files, by replacing the mei suffix with svg, instead of only appending `.svg` to the file path.